### PR TITLE
Rename writeEnvFile() to createEnvFile()

### DIFF
--- a/src/Codeception/Template/Lumiere.php
+++ b/src/Codeception/Template/Lumiere.php
@@ -224,7 +224,7 @@ class Lumiere extends Wpbrowser {
 
 		$filename = $this->workDir . DIRECTORY_SEPARATOR . $this->envFileName;
 
-		$this->writeEnvFile( $filename, $installation_data );
+		$this->createEnvFile( $filename, $installation_data );
 
 		$this->toIgnore[] = $this->envFileName;
 
@@ -238,7 +238,7 @@ class Lumiere extends Wpbrowser {
 
 			$filename = $this->workDir . DIRECTORY_SEPARATOR . $this->distEnvFilename;
 
-			$this->writeEnvFile( $filename, $data );
+			$this->createEnvFile( $filename, $data );
 		}
 	}
 
@@ -249,7 +249,7 @@ class Lumiere extends Wpbrowser {
 	 * @param string $filename desired filename
 	 * @param array $data data to write
 	 */
-	public function writeEnvFile( $filename, array $data ) {
+	public function createEnvFile( $filename, array $data ) {
 
 		$lines = [];
 


### PR DESCRIPTION
# Summary

This PR renames the `Lumiere::writeEnvFile()` method to `createEnvFile()` to avoid a conflict with the `Wpbroser::writeEnvFile()` method that was [introduced in wp-browser 2.4.7](https://github.com/lucatume/wp-browser/blob/393a4cc5c0c3b6a417d7715231dcf95e43b4b659/src/Codeception/Template/Wpbrowser.php#L460-L480)

<details>
    Warning: Declaration of Codeception\Template\Lumiere::writeEnvFile($filename, array $data) should be compatible with Codeception\Template\Wpbrowser::writeEnvFile(tad\WPBrowser\Utils\Map $installationData)
</details>

## Details

`Wpbroser::writeEnvFile()` replaced the protected `Wpbroser::creatEnvFile()` (note the missing `e` after the `t`), so I'm not sure if using `createEnvFile` is safe enough to use. Who knows if they decide to bring the other back without the typo in the near future.

I also considered `writeLumiereEnvFile()`, `writeEnvData()`, and `writeEnvFileData()`, but `createEnvFile` made sense to me as a companion for `createEnvFiles()`.