### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence the owner
+# will be requested for review when someone opens a pull request.
+*       @gdcorp-partners/mwc-engineering


### PR DESCRIPTION
# Summary

We will need to add a CODEOWNERS file to each repository under gdcorp-partners. The CODEOWNERS file should be committed in the root of the repo, and the following groups should be made the default owners

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->
**Main Story:** [mwc-130](https://jira.godaddy.com/browse/MWC-130)